### PR TITLE
Use acm.Certificate instead of deprecated acm.DnsValidatedCertificate…

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -38,7 +38,9 @@ export interface DomainRedirectorProps {
 }
 
 /**
- * SameDomainRedirector implements a simple CloudFront and S3 based HTTP(S) redirection.
+ * DomainRedirector implements an Level 3 CDK construct, whic
+ *
+ *  simple CloudFront and S3 based HTTP(S) redirection.
  *
  * Resource setup:
  * - S3 Bucket, that redirects all incoming requests to target domain
@@ -59,8 +61,7 @@ export class DomainRedirector extends Construct {
 
     const apex = props.hostedZone.zoneName.replace(/\.+$/, '');
     const invalid = props.domains.filter((domain) => domain != apex && !domain.endsWith('.' + apex));
-    if (invalid.length > 0)
-      throw new Error(`Hosted zone name ${apex} does not match all domains (${invalid.join(', ')})`);
+    if (invalid.length > 0) throw new Error(`Hosted zone name ${apex} does not match domains: ${invalid.join(', ')}`);
 
     this.bucket = this.initBucket(props);
     this.certificate = this.initCertificate(props);
@@ -81,11 +82,10 @@ export class DomainRedirector extends Construct {
   }
 
   private initCertificate(props: DomainRedirectorProps): acm.Certificate {
-    return new acm.DnsValidatedCertificate(this, 'Certificate', {
+    return new acm.Certificate(this, 'Certificate', {
       domainName: props.domains[0],
       ...(props.domains.length > 1 ? { subjectAlternativeNames: props.domains.slice(1) } : {}),
-      hostedZone: props.hostedZone,
-      region: 'us-east-1',
+      validation: acm.CertificateValidation.fromDns(props.hostedZone),
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -116,147 +116,35 @@ exports[`Domain Redirector Intended setup Has consistent snapshot 1`] = `
       },
       "Type": "AWS::CloudFront::CachePolicy",
     },
-    "MyTestConstructCertificateCertificateRequestorFunctionBE59448E": {
-      "DependsOn": [
-        "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7",
-        "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "861509f9607aa6bb9fd7034fb10fe6f0c60d91dfd7f010b9ef666869dec9bbd9.zip",
-        },
-        "Handler": "index.certificateRequestHandler",
-        "Role": {
-          "Fn::GetAtt": [
-            "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs14.x",
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "acm:RequestCertificate",
-                "acm:DescribeCertificate",
-                "acm:DeleteCertificate",
-                "acm:AddTagsToCertificate",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "route53:GetChange",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "route53:changeResourceRecordSets",
-              "Condition": {
-                "ForAllValues:StringEquals": {
-                  "route53:ChangeResourceRecordSetsActions": [
-                    "UPSERT",
-                  ],
-                  "route53:ChangeResourceRecordSetsRecordTypes": [
-                    "CNAME",
-                  ],
-                },
-                "ForAllValues:StringLike": {
-                  "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
-                    "*.www.domain.tld",
-                    "*.other.domain.tld",
-                  ],
-                },
-              },
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":route53:::hostedzone/",
-                    {
-                      "Ref": "HostedZoneDB99F866",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7",
-        "Roles": [
-          {
-            "Ref": "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "MyTestConstructCertificateCertificateRequestorResource5D7905BC": {
-      "DeletionPolicy": "Delete",
+    "MyTestConstructCertificate41948685": {
       "Properties": {
         "DomainName": "www.domain.tld",
-        "HostedZoneId": {
-          "Ref": "HostedZoneDB99F866",
-        },
-        "Region": "us-east-1",
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "MyTestConstructCertificateCertificateRequestorFunctionBE59448E",
-            "Arn",
-          ],
-        },
+        "DomainValidationOptions": [
+          {
+            "DomainName": "www.domain.tld",
+            "HostedZoneId": {
+              "Ref": "HostedZoneDB99F866",
+            },
+          },
+          {
+            "DomainName": "other.domain.tld",
+            "HostedZoneId": {
+              "Ref": "HostedZoneDB99F866",
+            },
+          },
+        ],
         "SubjectAlternativeNames": [
           "other.domain.tld",
         ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "TestStack/MyTestConstruct/Certificate",
+          },
+        ],
+        "ValidationMethod": "DNS",
       },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
+      "Type": "AWS::CertificateManager::Certificate",
     },
     "MyTestConstructDistribution60637A64": {
       "Properties": {
@@ -305,10 +193,7 @@ exports[`Domain Redirector Intended setup Has consistent snapshot 1`] = `
           ],
           "ViewerCertificate": {
             "AcmCertificateArn": {
-              "Fn::GetAtt": [
-                "MyTestConstructCertificateCertificateRequestorResource5D7905BC",
-                "Arn",
-              ],
+              "Ref": "MyTestConstructCertificate41948685",
             },
             "MinimumProtocolVersion": "TLSv1.2_2021",
             "SslSupportMethod": "sni-only",


### PR DESCRIPTION
… to create certificate which is validated using DNS records in hosted zone